### PR TITLE
Close GH issues #4 + #5: add .env.example and reorder setup steps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,50 @@
+# FireWatch environment configuration.
+#
+# Copy to `.env` (`cp .env.example .env`) and edit. Every variable below has
+# a sensible default in config.py — you only need to set what you want to
+# override. The pipeline runs end-to-end without any of these (writes
+# annotated MP4s to `clips/` locally), so you only need the AWS block if
+# you want S3 uploads.
+
+# ---------- Kafka ----------
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092
+KAFKA_VIDEO_TOPIC=video-frames
+KAFKA_DETECTIONS_TOPIC=fire-detections
+KAFKA_VIDEO_COMPLETIONS_TOPIC=video-completions
+KAFKA_GROUP_ID=firewatch-consumer-group
+
+# Partition counts (used by scripts/setup_kafka_topics.sh).
+# Increase to scale horizontally; one stream processor per partition is the
+# usual ceiling.
+KAFKA_VIDEO_TOPIC_PARTITIONS=6
+KAFKA_DETECTIONS_TOPIC_PARTITIONS=6
+KAFKA_VIDEO_COMPLETIONS_TOPIC_PARTITIONS=3
+
+# ---------- Video Processing ----------
+FRAME_EXTRACTION_INTERVAL=1   # 1 = every frame; 2 = every other; etc.
+FRAME_WIDTH=640
+FRAME_HEIGHT=480
+
+# ---------- ML Model ----------
+# Two backends are supported. fire-detect-nn (default) is a DenseNet121
+# binary classifier with GradCAM heatmaps. ultralytics is YOLOv8 with
+# bounding boxes. See docs/MODELS.md for full details.
+ML_MODEL_TYPE=fire-detect-nn        # fire-detect-nn | ultralytics
+ML_MODEL_SOURCE=fire-detect-nn      # fire-detect-nn | local | huggingface
+ML_MODEL_PATH=models/fire_detection_model.pt
+ML_MODEL_NAME=touatikamel/yolov8s-forest-fire-detection
+CONFIDENCE_THRESHOLD=0.5            # Binary probability (fire-detect-nn) or detection conf (YOLOv8)
+IOU_THRESHOLD=0.45                  # NMS IoU threshold (YOLOv8 only; ignored for fire-detect-nn)
+
+# ---------- Video Output ----------
+CLIP_STORAGE_PATH=clips             # Where annotated MP4s land locally
+CLIP_HEATMAP_OVERLAY_ALPHA=0.4      # 0.0-1.0; higher = more visible heatmap
+
+# ---------- S3 (optional) ----------
+# Only needed if you want the S3 upload consumer to push annotated MP4s
+# off the local box. Leave blank to keep everything local.
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=us-east-1
+S3_BUCKET=
+S3_DELETE_LOCAL_AFTER_UPLOAD=true   # Delete the local clip after a successful S3 upload

--- a/README.md
+++ b/README.md
@@ -95,16 +95,19 @@ Alternatively, install as a package (which includes fire-detect-nn installation)
 pip install -e .
 ```
 
-4. Run unit tests (optional):
+4. Configure environment variables:
+```bash
+cp .env.example .env
+# Defaults work for local-only runs; edit only if you want to point at a
+# remote Kafka cluster or enable S3 uploads.
+```
+
+5. Run unit tests (optional):
 ```bash
 pytest
 ```
 
-5. Configure environment variables:
-```bash
-cp .env.example .env
-# Edit .env with your Kafka and AWS credentials (for S3)
-```
+> The test suite mocks Kafka and S3, so it doesn't talk to real infrastructure — you don't need a running broker or an S3 bucket to run `pytest`, and you don't need to put any sample videos in S3.
 
 ### Environment Variables
 


### PR DESCRIPTION
## Summary

Resolves the two open issues filed against the repo, both of which hit the same speed bump on a fresh clone.

- Closes #4 — `pytest fails - missing instructions to create and configure env`
- Closes #5 — `Do i need to put test files in s3 bucket?`

## Background

Both reporters quote the same set of test failures:

- \`test_initialize_video_writer\` — \`assert None == 30.0\`
- \`test_upload_video_success\` — \`assert 'test-bucket' in 's3://...\`
- \`test_predict_fire_detect_nn\` / \`test_predict_yolo\` — \`ValueError: not enough values to unpack\`

**All four pass on current \`main\`** — the Phase 1 cleanup (PR #6) and Phase 2 split (PR #7) happened to fix them as side effects. Verified locally: 75/75 pytest pass on this branch.

So the actually-actionable bits from the issues are:

1. **\`cp .env.example .env\` fails** because the file isn't checked in.
2. **README ordering** — env setup currently comes after \`pytest\`, so the missing file blocks anyone following the README top-to-bottom.
3. **"Do I need test files in S3?"** — explicit one-liner answer in the README.

## Changes

### `.env.example` (new)

Covers every variable \`config.py\` reads, with the same defaults. Grouped by concern (Kafka, video processing, ML model, video output, S3) with comments. The AWS block is intentionally empty + flagged as optional — the pipeline runs end-to-end without S3 (writes annotated MP4s to \`clips/\` locally).

### `README.md` setup reordering

Old order: install deps → install fire-detect-nn → run pytest → copy .env.example.
New order: install deps → install fire-detect-nn → copy .env.example → run pytest.

Added one-liner under the pytest step:

> The test suite mocks Kafka and S3, so it doesn't talk to real infrastructure — you don't need a running broker or an S3 bucket to run \`pytest\`, and you don't need to put any sample videos in S3.

## Test plan

- [x] \`pytest\` passes (75/75).
- [x] \`cp .env.example .env\` works from a fresh checkout.
- [x] Following README steps top-to-bottom no longer hits a missing-file error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)