### PR TITLE
Phase 4: training pipeline + firewatch model backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,76 @@
+# FireWatch environment configuration.
+#
+# Copy to `.env` (`cp .env.example .env`) and edit. Every variable below has
+# a sensible default in config.py — you only need to set what you want to
+# override. The pipeline runs end-to-end without any of these (writes
+# annotated MP4s to `clips/` locally), so you only need the AWS block if
+# you want S3 uploads.
+
+# ---------- Kafka ----------
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092
+KAFKA_VIDEO_TOPIC=video-frames
+KAFKA_DETECTIONS_TOPIC=fire-detections
+KAFKA_VIDEO_COMPLETIONS_TOPIC=video-completions
+KAFKA_GROUP_ID=firewatch-consumer-group
+
+# Partition counts (used by scripts/setup_kafka_topics.sh).
+# Increase to scale horizontally; one stream processor per partition is the
+# usual ceiling.
+KAFKA_VIDEO_TOPIC_PARTITIONS=6
+KAFKA_DETECTIONS_TOPIC_PARTITIONS=6
+KAFKA_VIDEO_COMPLETIONS_TOPIC_PARTITIONS=3
+
+# ---------- Video Processing ----------
+FRAME_EXTRACTION_INTERVAL=1   # 1 = every frame; 2 = every other; etc.
+FRAME_WIDTH=640
+FRAME_HEIGHT=480
+
+# ---------- ML Model ----------
+# Three backends are supported. See docs/MODELS.md for full details.
+#   fire-detect-nn (default) — DenseNet121 classifier with GradCAM heatmaps
+#   ultralytics             — YOLOv8 with bounding boxes
+#   firewatch               — DenseNet121 trained in-house via `training/`
+#                             (see docs/TRAINING.md)
+ML_MODEL_TYPE=fire-detect-nn        # fire-detect-nn | ultralytics | firewatch
+ML_MODEL_SOURCE=fire-detect-nn      # fire-detect-nn | local | huggingface
+ML_MODEL_PATH=models/fire_detection_model.pt
+ML_MODEL_NAME=touatikamel/yolov8s-forest-fire-detection
+CONFIDENCE_THRESHOLD=0.5            # Binary probability (classifier backends) or detection conf (YOLOv8)
+IOU_THRESHOLD=0.45                  # NMS IoU threshold (YOLOv8 only; ignored for classifier backends)
+
+# Only used when ML_MODEL_TYPE=firewatch. Produced by `python -m training.export`.
+FIREWATCH_MODEL_PATH=models/firewatch-v1.pt
+
+# ---------- Video Output ----------
+CLIP_STORAGE_PATH=clips             # Where annotated MP4s land locally
+CLIP_HEATMAP_OVERLAY_ALPHA=0.4      # 0.0-1.0; higher = more visible heatmap
+
+# ---------- S3 (optional) ----------
+# Only needed if you want the S3 upload consumer to push annotated MP4s
+# off the local box. Leave blank to keep everything local.
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=us-east-1
+S3_BUCKET=
+S3_DELETE_LOCAL_AFTER_UPLOAD=true   # Delete the local clip after a successful S3 upload
+
+# ---------- Performance & latency (Phase 3) ----------
+# Offset commit cadence (whichever fires first).
+COMMIT_EVERY_N_MESSAGES=250
+COMMIT_INTERVAL_SECONDS=5.0
+
+# Compute GradCAM only on every Nth consecutive positive frame; reuse the
+# previous heatmap between. 1 = compute on every positive frame.
+GRADCAM_EVERY_N_FIRE_FRAMES=5
+
+# Run inference on every Nth frame. Skipped frames are still written to the
+# output video, just with the previous detection's heatmap. 1 = every frame.
+INFERENCE_EVERY_N_FRAMES=1
+
+# Frame transport over Kafka. 'msgpack' is ~33% smaller / ~5x faster decode
+# than 'base64-json'. Producer and stream MUST agree.
+FRAME_TRANSPORT=msgpack
+
+# fp16 autocast on CUDA. Off by default — at batch_size=1 the autocast
+# overhead actually slows the forward pass. Flip on with batched inference.
+ENABLE_AUTOCAST_CUDA=0

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ models/*
 *.pt
 yolov8n.pt  # YOLOv8 fallback model (not needed, use fire-detect-nn instead)
 
+# Training runs (TensorBoard events + intermediate checkpoints)
+training/runs/
+
 # Logs
 logs/
 *.log

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 raghuselvaraj
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -275,7 +275,8 @@ See [docs/MODELS.md](docs/MODELS.md) for detailed configuration of both fire-det
 ## Documentation
 
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — System components, data flow, deployment diagrams
-- [docs/MODELS.md](docs/MODELS.md) — Available models (fire-detect-nn, YOLOv8) and how to swap them
+- [docs/MODELS.md](docs/MODELS.md) — Available models (fire-detect-nn, YOLOv8, firewatch) and how to swap them
+- [docs/TRAINING.md](docs/TRAINING.md) — Train your own DenseNet121 fire classifier on D-Fire
 - [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) — Local stack, running each component, pytest, debugging
 - [docs/SCALING.md](docs/SCALING.md) — Horizontal scaling guide
 - [docs/PERFORMANCE.md](docs/PERFORMANCE.md) — Throughput tuning, current optimizations, bottlenecks

--- a/config.py
+++ b/config.py
@@ -21,14 +21,20 @@ FRAME_WIDTH = int(os.getenv("FRAME_WIDTH", "640"))
 FRAME_HEIGHT = int(os.getenv("FRAME_HEIGHT", "480"))
 
 # ML Model Configuration
-# Default: fire-detect-nn (DenseNet121) - recommended for fire detection with GradCAM heatmaps
-# Alternative: ultralytics (YOLOv8) - set ML_MODEL_TYPE=ultralytics to use
-ML_MODEL_TYPE = os.getenv("ML_MODEL_TYPE", "fire-detect-nn")  # 'ultralytics' or 'fire-detect-nn'
+# Supported ML_MODEL_TYPE values:
+#   'fire-detect-nn' (default) — upstream pretrained DenseNet121 with GradCAM
+#   'ultralytics'              — YOLOv8 (bounding-box detector)
+#   'firewatch'                — DenseNet121 trained in-house via `training/` (see docs/TRAINING.md)
+ML_MODEL_TYPE = os.getenv("ML_MODEL_TYPE", "fire-detect-nn")
 ML_MODEL_PATH = os.getenv("ML_MODEL_PATH", "models/fire_detection_model.pt")
 ML_MODEL_SOURCE = os.getenv("ML_MODEL_SOURCE", "fire-detect-nn")  # 'huggingface', 'local', 'roboflow', 'fire-detect-nn', or 'download'
 ML_MODEL_NAME = os.getenv("ML_MODEL_NAME", "touatikamel/yolov8s-forest-fire-detection")  # Only used if ML_MODEL_TYPE=ultralytics
-CONFIDENCE_THRESHOLD = float(os.getenv("CONFIDENCE_THRESHOLD", "0.5"))  # Binary probability threshold (fire-detect-nn) or YOLOv8 confidence
-IOU_THRESHOLD = float(os.getenv("IOU_THRESHOLD", "0.45"))  # NMS IoU threshold (YOLOv8 only; ignored for fire-detect-nn)
+CONFIDENCE_THRESHOLD = float(os.getenv("CONFIDENCE_THRESHOLD", "0.5"))  # Binary probability threshold (fire-detect-nn/firewatch) or YOLOv8 confidence
+IOU_THRESHOLD = float(os.getenv("IOU_THRESHOLD", "0.45"))  # NMS IoU threshold (YOLOv8 only; ignored for classifier backends)
+
+# Path to the FireWatch-trained checkpoint. Only used when ML_MODEL_TYPE=firewatch.
+# Produced by `python -m training.export --checkpoint <run>/best.pt`.
+FIREWATCH_MODEL_PATH = os.getenv("FIREWATCH_MODEL_PATH", "models/firewatch-v1.pt")
 
 # Video Output Configuration
 CLIP_STORAGE_PATH = os.getenv("CLIP_STORAGE_PATH", "clips")  # Output directory for annotated videos

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -1,13 +1,12 @@
 # Fire Detection Models
 
-FireWatch supports two model backends, selected via the `ML_MODEL_TYPE` environment variable.
+FireWatch supports three model backends, selected via the `ML_MODEL_TYPE` environment variable.
 
 | `ML_MODEL_TYPE` | Backend | Strengths |
 |---|---|---|
 | `fire-detect-nn` (default) | DenseNet121 binary classifier from [tomasz-lewicki/fire-detect-nn](https://github.com/tomasz-lewicki/fire-detect-nn) | Pretrained for fire; provides GradCAM heatmaps for visual fire-region overlay. |
 | `ultralytics` | YOLOv8 object detector via the [`ultralytics`](https://docs.ultralytics.com/) package | Provides bounding boxes; works with any YOLOv8 fire-trained checkpoint. |
-
-> A third option, `firewatch` (our own trained checkpoint), is planned for Phase 4 of the refactor. See `docs/TRAINING.md` once added.
+| `firewatch` | DenseNet121 binary classifier trained in-house on [D-Fire](https://github.com/gaiasd/DFireDataset) | Same architecture as fire-detect-nn but trained on a different dataset. See [TRAINING.md](TRAINING.md). |
 
 ---
 
@@ -93,6 +92,35 @@ IOU_THRESHOLD=0.45
 ### Class filtering
 
 YOLOv8 returns boxes for many object classes. The stream keeps boxes whose label matches any of `fire`, `smoke`, `flame`, `burn`, `wildfire` while excluding common false-positive labels (`fire hydrant`, `fire truck`, `extinguisher`, `alarm`, `station`, `engine`).
+
+---
+
+## firewatch (in-house trained)
+
+A DenseNet121 binary classifier trained on the public [D-Fire dataset](https://github.com/gaiasd/DFireDataset) by the `training/` pipeline. The architecture and inference normalization match `fire-detect-nn` — the difference is the training data and which weights get loaded.
+
+### Train + export
+
+See [TRAINING.md](TRAINING.md) for the full walkthrough. Short version:
+
+```bash
+python3 -m training.data.datasets --download
+python3 -m training.train --config training/configs/default.yaml
+python3 -m training.export --checkpoint training/runs/<run_id>/best.pt
+# → writes models/firewatch-v1.pt + models/firewatch-v1.metadata.json
+```
+
+### Configure
+
+In `.env`:
+
+```env
+ML_MODEL_TYPE=firewatch
+FIREWATCH_MODEL_PATH=models/firewatch-v1.pt
+CONFIDENCE_THRESHOLD=0.5
+```
+
+The stream behaves identically to the `fire-detect-nn` backend (same GradCAM, same full-frame bbox synthesis, same overlay rendering) — only the weights differ.
 
 ---
 

--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -1,0 +1,139 @@
+# Training the FireWatch model
+
+The `training/` package trains a DenseNet121 binary fire/no-fire classifier on
+the public [D-Fire](https://github.com/gaiasd/DFireDataset) dataset using the
+same `FireClassifier` architecture the stream's classifier backend uses. The
+resulting checkpoint is drop-in: load it via `ML_MODEL_TYPE=firewatch` and the
+existing inference path takes over.
+
+## Prerequisites
+
+- Python 3.11+, dependencies from `requirements.txt`:
+  ```bash
+  pip install -r requirements.txt
+  python3 scripts/install_fire_detect_nn.py     # provides FireClassifier + the input transform
+  ```
+- ~5 GB free disk for D-Fire (cloned into `~/.cache/firewatch/dfire/` by default).
+- Apple Silicon (MPS) or NVIDIA GPU recommended. CPU works but is slow.
+
+## Quickstart
+
+```bash
+# 1. Fetch the dataset (one-time, ~5 GB)
+python3 -m training.data.datasets --download
+# prints class balance: e.g. "train: 17211 images (10246 positive, 59.5% fire)"
+
+# 2. Smoke test — verifies the pipeline runs end-to-end without crashing
+python3 -m training.train --epochs 2 --batch_size 16 --max_steps 4
+
+# 3. Full training (~1.5–2.5 hours on Apple M-series)
+python3 -m training.train --config training/configs/default.yaml
+
+# 4. Evaluate on the held-out test split
+python3 -m training.eval --checkpoint training/runs/<run_id>/best.pt
+
+# 5. Export the deployable checkpoint to models/firewatch-v1.pt
+python3 -m training.export --checkpoint training/runs/<run_id>/best.pt
+```
+
+The exported checkpoint is then loadable by the stream:
+
+```bash
+ML_MODEL_TYPE=firewatch FIREWATCH_MODEL_PATH=models/firewatch-v1.pt python3 -m streams
+```
+
+## Default hyperparameters
+
+Defined in [`training/configs/default.yaml`](../training/configs/default.yaml).
+
+| Param | Value | Notes |
+|---|---|---|
+| `model.backbone` | `densenet121` | Matches upstream fire-detect-nn; required for the inference path to work unchanged. |
+| `model.pretrained` | `true` | ImageNet init. |
+| `training.batch_size` | 32 | Fits MPS comfortably at 224×224. |
+| `training.epochs` | 20 | ~12k optimizer steps on D-Fire train. |
+| `training.lr` | 1e-4 | AdamW. |
+| `training.weight_decay` | 1e-4 | |
+| `training.warmup_epochs` | 1 | LinearLR → CosineAnnealingLR. |
+| `data.val_frac` | 0.1 | 10% of `train/` held out as val (seed 4822 — matches upstream). |
+| `data.num_workers` | 4 | Drop to 0 if MPS multiprocessing flakes. |
+
+Override any of these via CLI flags or by editing the YAML.
+
+## How the architecture stays in sync with inference
+
+The deployed `streams/models/firewatch.py` backend instantiates the upstream
+`FireClassifier(backbone="densenet121", pretrained=False)` and loads our
+state_dict on top. To make a training-time model produce the same
+`state_dict` keys:
+
+- `training/model.py:build_model` instantiates `FireClassifier(pretrained=True)`,
+  then **replaces `model.sigmoid` with `nn.Identity()`**. This lets training
+  use `BCEWithLogitsLoss` against logits (numerically stable).
+- `training/export.py` loads `best.pt` into a stock `FireClassifier`
+  (which has `nn.Sigmoid()` at the head) and re-saves. The sigmoid module
+  has no parameters, so the state_dict is identical either way.
+
+End result: `models/firewatch-v{N}.pt` is structurally indistinguishable from
+the upstream pretrained checkpoint and uses the same input normalization
+(`mean=(0.4005, 0.3702, 0.3419)`, `std=(0.2858, 0.2749, 0.2742)`, 224×224)
+imported directly from `fire_detect_nn.datasets.combo`.
+
+## Dataset details
+
+D-Fire ships with `train/` and `test/` subdirectories of YOLO-format
+annotations:
+
+```
+~/.cache/firewatch/dfire/
+├── train/
+│   ├── images/  *.jpg
+│   └── labels/  *.txt          # one line per box; empty = no fire/smoke
+└── test/
+    ├── images/
+    └── labels/
+```
+
+Binary collapse: a non-empty `.txt` → label 1, empty (or missing) → label 0.
+Both fire *and* smoke boxes collapse to the positive class; preserving the
+distinction is future work (see "Out of scope" in the master plan).
+
+## Outputs
+
+Each run lands in `training/runs/<run_id>/` with:
+
+| File | Content |
+|---|---|
+| `config.json` | The fully-resolved hyperparams used (YAML + CLI overrides). |
+| `last.pt` | State_dict from the latest epoch (for resuming). |
+| `best.pt` | State_dict from the epoch with the best val AUROC. |
+| `best_metrics.json` | Epoch index + val metrics for the best checkpoint. |
+| `events.out.tfevents.*` | TensorBoard scalars (train_loss, val_loss, val_auroc, val_pr_auc, lr). |
+
+View live: `tensorboard --logdir training/runs/`.
+
+## Troubleshooting
+
+**MPS OOM at batch_size=32**: drop to 16. DenseNet121 at 224×224 fp32 is
+~28M params + activations; an 8 GB unified-memory M1 can be tight if other
+apps are running.
+
+**`num_workers > 0` hangs on macOS**: known torch+multiprocessing flakiness.
+Set `data.num_workers: 0` in the YAML or `--num_workers 0` on the CLI.
+
+**Slow first epoch**: PIL JPEG decoding on the data path dominates wall-clock
+on Apple Silicon. The model is fast; the bottleneck is image loading.
+Increasing `num_workers` helps when it doesn't hang (see above).
+
+**`val_auroc` stuck at 0.0**: the val split likely has only one class. Increase
+`val_frac` or check class balance with `python -m training.data.datasets`.
+
+**Want to train a single short run**: `--epochs 2 --max_steps 100 --batch_size 16`
+takes ~5 minutes on MPS and is enough to confirm the loss is decreasing.
+
+## Performance target
+
+The first PR ships the pipeline regardless of accuracy — tuning is an
+incremental follow-up. Aspirational target on the default config: **val AUROC
+≥ 0.85** on the D-Fire test split. Numbers from the actual training run will
+land in `docs/MODELS.md` and the v1 checkpoint metadata.

--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -11,8 +11,11 @@ existing inference path takes over.
 - Python 3.11+, dependencies from `requirements.txt`:
   ```bash
   pip install -r requirements.txt
-  python3 scripts/install_fire_detect_nn.py     # provides FireClassifier + the input transform
   ```
+  No external ML packages beyond `requirements.txt` are needed — the
+  `FireClassifier` architecture and input normalization are defined locally
+  in [`streams/models/fire_classifier.py`](../streams/models/fire_classifier.py)
+  and [`streams/models/preprocessing.py`](../streams/models/preprocessing.py).
 - ~5 GB free disk for D-Fire (cloned into `~/.cache/firewatch/dfire/` by default).
 - Apple Silicon (MPS) or NVIDIA GPU recommended. CPU works but is slow.
 
@@ -74,10 +77,10 @@ state_dict on top. To make a training-time model produce the same
   (which has `nn.Sigmoid()` at the head) and re-saves. The sigmoid module
   has no parameters, so the state_dict is identical either way.
 
-End result: `models/firewatch-v{N}.pt` is structurally indistinguishable from
-the upstream pretrained checkpoint and uses the same input normalization
+End result: `models/firewatch-v{N}.pt` is structurally identical to the
+legacy fire-detect-nn checkpoint format and uses the same input normalization
 (`mean=(0.4005, 0.3702, 0.3419)`, `std=(0.2858, 0.2749, 0.2742)`, 224×224)
-imported directly from `fire_detect_nn.datasets.combo`.
+defined in [`streams/models/preprocessing.py`](../streams/models/preprocessing.py).
 
 ## Dataset details
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,12 @@ pytest-cov>=4.1.0
 pytest-mock>=3.12.0
 pytest-asyncio>=0.21.0
 
+# Training pipeline (see training/ and docs/TRAINING.md)
+scikit-learn>=1.3.0
+tensorboard>=2.14.0
+tqdm>=4.66.0
+PyYAML>=6.0
+
 # Note: fire-detect-nn is installed automatically via scripts/install_fire_detect_nn.py
 # Run: python3 scripts/install_fire_detect_nn.py
 # Or install the package: pip install -e .  (which runs the install script)

--- a/scripts/install_fire_detect_nn.py
+++ b/scripts/install_fire_detect_nn.py
@@ -104,7 +104,8 @@ def install_fire_detect_nn():
     print(f"\n✓ fire-detect-nn installed successfully!")
     print(f"   Location: {fire_detect_nn_dir}")
     print(f"   Weights: {weights_file}")
-    print(f"\nYou can now import it with: from fire_detect_nn.models import FireClassifier")
+    print(f"\nThe legacy 'fire-detect-nn' backend can now load these weights.")
+    print(f"For new deployments prefer ML_MODEL_TYPE=firewatch (see docs/TRAINING.md).")
     
     return True
 

--- a/streams/models/classifier_predictor.py
+++ b/streams/models/classifier_predictor.py
@@ -1,0 +1,152 @@
+"""Shared base for binary-classifier fire backends.
+
+Both ``FireDetectNN`` (upstream pretrained) and ``FireWatch`` (trained in
+``training/``) use the same ``FireClassifier`` architecture from the
+fire-detect-nn package and the same input normalization. The only difference
+is where the weights come from. This base class owns everything except that:
+device selection, GradCAM cadence state, and the ``predict()`` method.
+
+Subclasses override ``_load_weights(device) -> (model, transform)`` and set
+``MODEL_TYPE``.
+"""
+import os
+from datetime import datetime
+from typing import Any, Dict, Optional, Tuple
+
+import cv2
+import numpy as np
+
+from streams.models.gradcam import compute_gradcam_heatmap
+
+
+class FireClassifierPredictor:
+    """Base class for binary fire/no-fire classifier backends.
+
+    The output dict is shaped to match the YOLOv8 detector for downstream
+    compatibility: a full-frame ``bbox`` covering the entire frame is
+    synthesized when fire is detected, since the classifier doesn't produce
+    bounding boxes natively.
+
+    GradCAM cadence: if ``gradcam_every_n_fire_frames`` > 1, the heatmap is
+    only recomputed every Nth consecutive positive frame and the previous
+    heatmap is reused on the frames in between. Set to 1 for the legacy
+    "compute on every positive frame" behavior.
+    """
+
+    MODEL_TYPE: str = "abstract"
+
+    def __init__(self, confidence_threshold: float, gradcam_every_n_fire_frames: int = 1):
+        self.confidence_threshold = confidence_threshold
+        self.gradcam_every_n_fire_frames = max(1, gradcam_every_n_fire_frames)
+        self._consecutive_fire_frames = 0
+        self._last_heatmap: Optional[np.ndarray] = None
+        self.device = self._select_device()
+        self.model, self.fire_transform = self._load_weights(self.device)
+
+    @staticmethod
+    def _select_device():
+        """Prefer CUDA, then Apple MPS, then CPU."""
+        import torch
+
+        if torch.cuda.is_available():
+            print("  Using CUDA (NVIDIA GPU) for acceleration")
+            return torch.device("cuda")
+        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+            print("  Using MPS (Apple Silicon GPU) for acceleration")
+            return torch.device("mps")
+        print("  Using CPU (no GPU acceleration available)")
+        return torch.device("cpu")
+
+    def _load_weights(self, device) -> Tuple[Any, Any]:
+        raise NotImplementedError("subclasses must implement _load_weights")
+
+    def predict(self, frame: np.ndarray) -> Dict[str, Any]:
+        """Classify a frame as fire / no-fire and (on positive) compute GradCAM.
+
+        Args:
+            frame: BGR numpy array straight from OpenCV.
+
+        Returns:
+            Dict with ``has_fire``, ``fire_probability``, ``detections``,
+            ``timestamp``, ``model_type``, ``no_fire_probability``, and
+            (when fire is detected) a ``heatmap`` 2D numpy array.
+        """
+        try:
+            import torch
+            from PIL import Image
+
+            frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            pil_image = Image.fromarray(frame_rgb)
+            input_tensor = self.fire_transform(pil_image).unsqueeze(0).to(self.device)
+
+            # fp16 autocast on CUDA is gated behind ENABLE_AUTOCAST_CUDA because
+            # at batch_size=1 the autocast context overhead actually slows the
+            # forward pass down (verified: ~22% slower on T4 at batch_size=1).
+            use_autocast = (
+                self.device.type == "cuda"
+                and os.getenv("ENABLE_AUTOCAST_CUDA", "0").lower() in ("1", "true", "yes")
+            )
+            with torch.no_grad():
+                if use_autocast:
+                    with torch.autocast(device_type="cuda", dtype=torch.float16):
+                        output = self.model(input_tensor)
+                else:
+                    output = self.model(input_tensor)
+                fire_prob = output[0].cpu().item()
+                no_fire_prob = 1.0 - fire_prob
+
+            has_fire = fire_prob >= self.confidence_threshold
+
+            heatmap: Optional[np.ndarray] = None
+            if has_fire:
+                self._consecutive_fire_frames += 1
+                position = (self._consecutive_fire_frames - 1) % self.gradcam_every_n_fire_frames
+                if position == 0:
+                    try:
+                        new_heatmap = compute_gradcam_heatmap(
+                            self.model, self.fire_transform, self.device, frame
+                        )
+                        if new_heatmap is not None:
+                            self._last_heatmap = new_heatmap
+                    except Exception:
+                        pass
+                heatmap = self._last_heatmap
+            else:
+                self._consecutive_fire_frames = 0
+                self._last_heatmap = None
+
+            detections = []
+            if has_fire:
+                h, w = frame.shape[:2]
+                detections.append(
+                    {
+                        "bbox": [0, 0, w, h],
+                        "confidence": fire_prob,
+                        "class": "fire",
+                        "class_id": 1,
+                    }
+                )
+
+            return {
+                "has_fire": bool(has_fire),
+                "fire_probability": float(fire_prob) if has_fire else 0.0,
+                "detections": detections,
+                "timestamp": datetime.utcnow().isoformat(),
+                "model_type": self.MODEL_TYPE,
+                "no_fire_probability": float(no_fire_prob),
+                "heatmap": heatmap,
+            }
+
+        except Exception as e:
+            print(f"Error in {self.MODEL_TYPE} prediction: {e}")
+            import traceback
+
+            traceback.print_exc()
+            return {
+                "has_fire": False,
+                "fire_probability": 0.0,
+                "detections": [],
+                "timestamp": datetime.utcnow().isoformat(),
+                "model_type": self.MODEL_TYPE,
+                "error": str(e),
+            }

--- a/streams/models/dispatcher.py
+++ b/streams/models/dispatcher.py
@@ -1,6 +1,7 @@
 """Unified ``FireDetectionModel`` that dispatches to a backend.
 
-Loads either :class:`~streams.models.fire_detect_nn.FireDetectNN` or
+Loads :class:`~streams.models.fire_detect_nn.FireDetectNN`,
+:class:`~streams.models.firewatch.FireWatch`, or
 :class:`~streams.models.yolov8.YOLOv8Detector` depending on ``ML_MODEL_TYPE``
 (and the legacy ``ML_MODEL_SOURCE`` alias). The dispatcher itself owns the
 config plumbing so the backends stay decoupled from the env.
@@ -19,9 +20,10 @@ warnings.filterwarnings("ignore", message=".*x265.*")
 
 # Pre-check that fire-detect-nn is importable when configured. This early
 # warning is helpful at startup; the actual import still happens lazily inside
-# the backend's loader.
+# the backend's loader. The `firewatch` backend also depends on the
+# fire-detect-nn package (it reuses FireClassifier), so include it here.
 FIRE_DETECT_NN_AVAILABLE = False
-if config.ML_MODEL_TYPE == "fire-detect-nn" or config.ML_MODEL_SOURCE == "fire-detect-nn":
+if config.ML_MODEL_TYPE in ("fire-detect-nn", "firewatch") or config.ML_MODEL_SOURCE == "fire-detect-nn":
     try:
         import fire_detect_nn  # noqa: F401
 
@@ -37,7 +39,7 @@ class FireDetectionModel:
     Reads its configuration from :mod:`config` and constructs the appropriate
     backend. Exposes ``predict(frame) -> dict`` (matching either backend) and
     keeps the same public attributes the old monolith had: ``model``,
-    ``device`` (fire-detect-nn only), ``fire_transform`` (ditto),
+    ``device`` (classifier backends only), ``fire_transform`` (ditto),
     ``confidence_threshold``, ``iou_threshold``, ``use_fire_detect_nn``.
     """
 
@@ -52,7 +54,19 @@ class FireDetectionModel:
             self.model_type == "fire-detect-nn" or self.model_source == "fire-detect-nn"
         )
 
-        if self.use_fire_detect_nn:
+        if self.model_type == "firewatch":
+            from streams.models.firewatch import FireWatch
+
+            self._backend = FireWatch(
+                model_path=getattr(config, "FIREWATCH_MODEL_PATH", "models/firewatch-v1.pt"),
+                confidence_threshold=self.confidence_threshold,
+                gradcam_every_n_fire_frames=getattr(config, "GRADCAM_EVERY_N_FIRE_FRAMES", 1),
+            )
+            self.model = self._backend.model
+            self.device = self._backend.device
+            self.fire_transform = self._backend.fire_transform
+            print("firewatch model initialized (DenseNet121, in-house trained)")
+        elif self.use_fire_detect_nn:
             from streams.models.fire_detect_nn import FireDetectNN
 
             self._backend = FireDetectNN(

--- a/streams/models/dispatcher.py
+++ b/streams/models/dispatcher.py
@@ -18,17 +18,20 @@ warnings.filterwarnings("ignore", category=UserWarning, module="torchvision")
 warnings.filterwarnings("ignore", message=".*x265.*")
 
 
-# Pre-check that fire-detect-nn is importable when configured. This early
-# warning is helpful at startup; the actual import still happens lazily inside
-# the backend's loader. The `firewatch` backend also depends on the
-# fire-detect-nn package (it reuses FireClassifier), so include it here.
+# Pre-check that the fire-detect-nn weights directory is reachable when the
+# legacy backend is configured. The firewatch backend uses our in-project
+# FireClassifier + our own trained checkpoint and does not need the upstream
+# package at all.
 FIRE_DETECT_NN_AVAILABLE = False
-if config.ML_MODEL_TYPE in ("fire-detect-nn", "firewatch") or config.ML_MODEL_SOURCE == "fire-detect-nn":
+if config.ML_MODEL_TYPE == "fire-detect-nn" or config.ML_MODEL_SOURCE == "fire-detect-nn":
     try:
-        import fire_detect_nn  # noqa: F401
+        import importlib.util
 
-        FIRE_DETECT_NN_AVAILABLE = True
-        print("✓ fire-detect-nn found in site-packages")
+        if importlib.util.find_spec("fire_detect_nn") is not None:
+            FIRE_DETECT_NN_AVAILABLE = True
+            print("✓ fire-detect-nn weights directory found")
+        else:
+            print("⚠️  fire-detect-nn not installed. Run: python3 scripts/install_fire_detect_nn.py")
     except ImportError:
         print("⚠️  fire-detect-nn not installed. Run: python3 scripts/install_fire_detect_nn.py")
 

--- a/streams/models/fire_classifier.py
+++ b/streams/models/fire_classifier.py
@@ -1,0 +1,46 @@
+"""DenseNet121 binary fire/no-fire classifier.
+
+Independent reimplementation of the architecture used by both
+:class:`~streams.models.fire_detect_nn.FireDetectNN` and
+:class:`~streams.models.firewatch.FireWatch`. Kept in-project so we don't
+depend on the unlicensed upstream ``fire_detect_nn.models.FireClassifier``.
+
+State-dict layout matches the upstream class exactly — ``backbone.*`` keys
+from ``torchvision.models.densenet121`` plus a ``backbone.classifier``
+``Linear(1024, 1)`` head — so existing checkpoints load without conversion.
+"""
+from __future__ import annotations
+
+import torch.nn as nn
+import torchvision.models as tv_models
+
+
+class FireClassifier(nn.Module):
+    """DenseNet121 backbone + 1-unit Linear head + sigmoid.
+
+    Args:
+        backbone: Only ``"densenet121"`` is supported. The argument exists
+            for call-site compatibility with the previous upstream class.
+        pretrained: If True, init the backbone with torchvision's ImageNet1k
+            weights (BSD-licensed). False = random init (for loading an
+            existing state_dict on top).
+    """
+
+    def __init__(self, backbone: str = "densenet121", pretrained: bool = True):
+        super().__init__()
+        if backbone != "densenet121":
+            raise NotImplementedError(
+                f"FireClassifier only supports backbone='densenet121', got {backbone!r}"
+            )
+        if pretrained:
+            self.backbone = tv_models.densenet121(weights=tv_models.DenseNet121_Weights.IMAGENET1K_V1)
+        else:
+            self.backbone = tv_models.densenet121(weights=None)
+        # Replace the 1000-class ImageNet head with a single fire/no-fire logit.
+        self.backbone.classifier = nn.Linear(in_features=1024, out_features=1, bias=True)
+        self.sigmoid = nn.Sigmoid()
+
+    def forward(self, x):
+        x = self.backbone(x)
+        x = self.sigmoid(x)
+        return x

--- a/streams/models/fire_detect_nn.py
+++ b/streams/models/fire_detect_nn.py
@@ -1,14 +1,21 @@
-"""Backend for the fire-detect-nn DenseNet121 binary classifier.
+"""Backend for the legacy fire-detect-nn DenseNet121 pretrained weights.
 
-The upstream package is fetched into site-packages by
-``scripts/install_fire_detect_nn.py``. This module assumes that import
-``fire_detect_nn`` succeeds and that the pretrained weights file lives at
-``<site-packages>/fire_detect_nn/weights/firedetect-densenet121-pretrained.pt``.
+Loads the upstream pretrained `.pt` file fetched by
+``scripts/install_fire_detect_nn.py`` into our in-project
+:class:`~streams.models.fire_classifier.FireClassifier` (which has the same
+architecture). The fire-detect-nn Python package is not imported — only its
+weights file is consumed.
+
+For new deployments prefer ``ML_MODEL_TYPE=firewatch`` with the in-house
+trained checkpoint (see docs/TRAINING.md). This backend is kept as an
+opt-in for users with the upstream weights already installed.
 """
 from pathlib import Path
 from typing import Any, Tuple
 
 from streams.models.classifier_predictor import FireClassifierPredictor
+from streams.models.fire_classifier import FireClassifier
+from streams.models.preprocessing import build_inference_transform
 
 
 class FireDetectNN(FireClassifierPredictor):
@@ -19,38 +26,39 @@ class FireDetectNN(FireClassifierPredictor):
     def _load_weights(self, device) -> Tuple[Any, Any]:
         try:
             import torch
-            import fire_detect_nn
-            from fire_detect_nn.models import FireClassifier
-            from fire_detect_nn.datasets.combo import transform as fire_transform
-
-            pkg_path = Path(fire_detect_nn.__file__).parent
-            weights_path = pkg_path / "weights" / "firedetect-densenet121-pretrained.pt"
-            print(f"Using fire-detect-nn from: {pkg_path}")
-
-            if not weights_path.exists():
-                raise FileNotFoundError(
-                    f"fire-detect-nn weights not found: {weights_path}\n"
-                    "Run: python3 scripts/install_fire_detect_nn.py to download weights"
-                )
-
-            print(f"Loading fire-detect-nn model from: {weights_path}")
-
-            model = FireClassifier(backbone="densenet121", pretrained=False)
-            state_dict = torch.load(weights_path, map_location=device)
-            model.load_state_dict(state_dict)
-            model.eval()
-            model.to(device)
-
-            print(f"✓ fire-detect-nn model loaded successfully on {device}")
-            return model, fire_transform
-
         except ImportError as e:
-            raise ImportError(
-                "Required modules not found. Make sure fire-detect-nn is installed.\n"
-                "Run: python3 scripts/install_fire_detect_nn.py\n"
-                f"Original error: {e}"
+            raise ImportError(f"torch required: {e}")
+
+        # The install script puts the upstream package + weights file under
+        # site-packages/fire_detect_nn/weights/. We only need the weights file
+        # — locate it without importing the package.
+        try:
+            import importlib.util
+
+            spec = importlib.util.find_spec("fire_detect_nn")
+            if spec is None or spec.origin is None:
+                raise FileNotFoundError("fire_detect_nn package directory not found")
+            pkg_path = Path(spec.origin).parent
+        except (ImportError, FileNotFoundError):
+            raise FileNotFoundError(
+                "Could not locate fire-detect-nn weights directory.\n"
+                "Run: python3 scripts/install_fire_detect_nn.py to install it,\n"
+                "or use ML_MODEL_TYPE=firewatch with your own trained checkpoint."
             )
-        except FileNotFoundError:
-            raise
-        except Exception as e:
-            raise RuntimeError(f"Failed to load fire-detect-nn model: {e}")
+
+        weights_path = pkg_path / "weights" / "firedetect-densenet121-pretrained.pt"
+        if not weights_path.exists():
+            raise FileNotFoundError(
+                f"fire-detect-nn weights not found: {weights_path}\n"
+                "Run: python3 scripts/install_fire_detect_nn.py to download weights"
+            )
+
+        print(f"Loading fire-detect-nn weights from: {weights_path}")
+        model = FireClassifier(backbone="densenet121", pretrained=False)
+        state_dict = torch.load(weights_path, map_location=device)
+        model.load_state_dict(state_dict)
+        model.eval()
+        model.to(device)
+        print(f"✓ fire-detect-nn model loaded successfully on {device}")
+
+        return model, build_inference_transform()

--- a/streams/models/fire_detect_nn.py
+++ b/streams/models/fire_detect_nn.py
@@ -5,54 +5,18 @@ The upstream package is fetched into site-packages by
 ``fire_detect_nn`` succeeds and that the pretrained weights file lives at
 ``<site-packages>/fire_detect_nn/weights/firedetect-densenet121-pretrained.pt``.
 """
-import os
-from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Tuple
 
-import cv2
-import numpy as np
-
-from streams.models.gradcam import compute_gradcam_heatmap
+from streams.models.classifier_predictor import FireClassifierPredictor
 
 
-class FireDetectNN:
-    """DenseNet121 fire/no-fire classifier with optional GradCAM heatmap.
+class FireDetectNN(FireClassifierPredictor):
+    """DenseNet121 fire/no-fire classifier loaded from upstream pretrained weights."""
 
-    The output dict is shaped to match the YOLOv8 detector for downstream
-    compatibility: a full-frame ``bbox`` covering the entire frame is
-    synthesized when fire is detected, since the classifier doesn't produce
-    bounding boxes natively.
+    MODEL_TYPE = "fire-detect-nn"
 
-    GradCAM cadence: if ``gradcam_every_n_fire_frames`` > 1, the heatmap is
-    only recomputed every Nth consecutive positive frame and the previous
-    heatmap is reused on the frames in between. Set to 1 for the legacy
-    "compute on every positive frame" behavior.
-    """
-
-    def __init__(self, confidence_threshold: float, gradcam_every_n_fire_frames: int = 1):
-        self.confidence_threshold = confidence_threshold
-        self.gradcam_every_n_fire_frames = max(1, gradcam_every_n_fire_frames)
-        self._consecutive_fire_frames = 0
-        self._last_heatmap: Optional[np.ndarray] = None
-        self.model, self.device, self.fire_transform = self._load()
-
-    @staticmethod
-    def _select_device():
-        """Prefer CUDA, then Apple MPS, then CPU."""
-        import torch
-
-        if torch.cuda.is_available():
-            print("  Using CUDA (NVIDIA GPU) for acceleration")
-            return torch.device("cuda")
-        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-            print("  Using MPS (Apple Silicon GPU) for acceleration")
-            return torch.device("mps")
-        print("  Using CPU (no GPU acceleration available)")
-        return torch.device("cpu")
-
-    @staticmethod
-    def _load():
+    def _load_weights(self, device) -> Tuple[Any, Any]:
         try:
             import torch
             import fire_detect_nn
@@ -71,7 +35,6 @@ class FireDetectNN:
 
             print(f"Loading fire-detect-nn model from: {weights_path}")
 
-            device = FireDetectNN._select_device()
             model = FireClassifier(backbone="densenet121", pretrained=False)
             state_dict = torch.load(weights_path, map_location=device)
             model.load_state_dict(state_dict)
@@ -79,7 +42,7 @@ class FireDetectNN:
             model.to(device)
 
             print(f"✓ fire-detect-nn model loaded successfully on {device}")
-            return model, device, fire_transform
+            return model, fire_transform
 
         except ImportError as e:
             raise ImportError(
@@ -87,103 +50,7 @@ class FireDetectNN:
                 "Run: python3 scripts/install_fire_detect_nn.py\n"
                 f"Original error: {e}"
             )
+        except FileNotFoundError:
+            raise
         except Exception as e:
             raise RuntimeError(f"Failed to load fire-detect-nn model: {e}")
-
-    def predict(self, frame: np.ndarray) -> Dict[str, Any]:
-        """Classify a frame as fire / no-fire and (on positive) compute GradCAM.
-
-        Args:
-            frame: BGR numpy array straight from OpenCV.
-
-        Returns:
-            Dict with ``has_fire``, ``fire_probability``, ``detections``,
-            ``timestamp``, ``model_type``, ``no_fire_probability``, and
-            (when fire is detected) a ``heatmap`` 2D numpy array.
-        """
-        try:
-            import torch
-            from PIL import Image
-
-            frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-            pil_image = Image.fromarray(frame_rgb)
-            input_tensor = self.fire_transform(pil_image).unsqueeze(0).to(self.device)
-
-            # fp16 autocast on CUDA is gated behind ENABLE_AUTOCAST_CUDA because
-            # at batch_size=1 the autocast context overhead actually slows the
-            # forward pass down (verified: ~22% slower on T4 at batch_size=1).
-            # Autocast becomes a win at batch_size >= 16 or so, where fp16
-            # matmul speedups overshadow the dtype-tracking overhead. Phase 3
-            # ships with batch_size=1, so this defaults to off; flip it on
-            # alongside batched inference in a Phase 3 follow-up.
-            use_autocast = (
-                self.device.type == "cuda"
-                and os.getenv("ENABLE_AUTOCAST_CUDA", "0").lower() in ("1", "true", "yes")
-            )
-            with torch.no_grad():
-                if use_autocast:
-                    with torch.autocast(device_type="cuda", dtype=torch.float16):
-                        output = self.model(input_tensor)
-                else:
-                    output = self.model(input_tensor)
-                fire_prob = output[0].cpu().item()
-                no_fire_prob = 1.0 - fire_prob
-
-            has_fire = fire_prob >= self.confidence_threshold
-
-            heatmap: Optional[np.ndarray] = None
-            if has_fire:
-                self._consecutive_fire_frames += 1
-                # Recompute the heatmap on the first positive after a non-fire
-                # gap, and every Nth positive thereafter. Reuse otherwise.
-                position = (self._consecutive_fire_frames - 1) % self.gradcam_every_n_fire_frames
-                if position == 0:
-                    try:
-                        new_heatmap = compute_gradcam_heatmap(
-                            self.model, self.fire_transform, self.device, frame
-                        )
-                        if new_heatmap is not None:
-                            self._last_heatmap = new_heatmap
-                    except Exception:
-                        # GradCAM is optional; fall through with the cached heatmap.
-                        pass
-                heatmap = self._last_heatmap
-            else:
-                self._consecutive_fire_frames = 0
-                self._last_heatmap = None
-
-            detections = []
-            if has_fire:
-                h, w = frame.shape[:2]
-                detections.append(
-                    {
-                        "bbox": [0, 0, w, h],
-                        "confidence": fire_prob,
-                        "class": "fire",
-                        "class_id": 1,
-                    }
-                )
-
-            return {
-                "has_fire": bool(has_fire),
-                "fire_probability": float(fire_prob) if has_fire else 0.0,
-                "detections": detections,
-                "timestamp": datetime.utcnow().isoformat(),
-                "model_type": "fire-detect-nn",
-                "no_fire_probability": float(no_fire_prob),
-                "heatmap": heatmap,
-            }
-
-        except Exception as e:
-            print(f"Error in fire-detect-nn prediction: {e}")
-            import traceback
-
-            traceback.print_exc()
-            return {
-                "has_fire": False,
-                "fire_probability": 0.0,
-                "detections": [],
-                "timestamp": datetime.utcnow().isoformat(),
-                "model_type": "fire-detect-nn",
-                "error": str(e),
-            }

--- a/streams/models/firewatch.py
+++ b/streams/models/firewatch.py
@@ -1,0 +1,57 @@
+"""Backend for the FireWatch in-house DenseNet121 binary classifier.
+
+Architecturally identical to ``FireDetectNN`` — both load the same
+``FireClassifier`` from the fire-detect-nn package — but the weights come from
+``models/firewatch-v{N}.pt`` produced by ``training/`` rather than the upstream
+pretrained checkpoint. The shared inference path lives in
+:class:`~streams.models.classifier_predictor.FireClassifierPredictor`.
+"""
+from pathlib import Path
+from typing import Any, Tuple
+
+from streams.models.classifier_predictor import FireClassifierPredictor
+
+
+class FireWatch(FireClassifierPredictor):
+    """FireClassifier loaded from a FireWatch-trained checkpoint."""
+
+    MODEL_TYPE = "firewatch"
+
+    def __init__(
+        self,
+        model_path: str,
+        confidence_threshold: float,
+        gradcam_every_n_fire_frames: int = 1,
+    ):
+        self.model_path = model_path
+        super().__init__(confidence_threshold, gradcam_every_n_fire_frames)
+
+    def _load_weights(self, device) -> Tuple[Any, Any]:
+        try:
+            import torch
+            from fire_detect_nn.models import FireClassifier
+            from fire_detect_nn.datasets.combo import transform as fire_transform
+        except ImportError as e:
+            raise ImportError(
+                "fire-detect-nn package required for FireClassifier architecture.\n"
+                "Run: python3 scripts/install_fire_detect_nn.py\n"
+                f"Original error: {e}"
+            )
+
+        weights_path = Path(self.model_path)
+        if not weights_path.exists():
+            raise FileNotFoundError(
+                f"FireWatch weights not found: {weights_path}\n"
+                "Train a model first: python3 -m training.train\n"
+                "Then export: python3 -m training.export --checkpoint <run>/best.pt"
+            )
+
+        print(f"Loading FireWatch model from: {weights_path}")
+        model = FireClassifier(backbone="densenet121", pretrained=False)
+        state_dict = torch.load(weights_path, map_location=device)
+        model.load_state_dict(state_dict)
+        model.eval()
+        model.to(device)
+        print(f"✓ FireWatch model loaded successfully on {device}")
+
+        return model, fire_transform

--- a/streams/models/firewatch.py
+++ b/streams/models/firewatch.py
@@ -1,15 +1,16 @@
 """Backend for the FireWatch in-house DenseNet121 binary classifier.
 
-Architecturally identical to ``FireDetectNN`` — both load the same
-``FireClassifier`` from the fire-detect-nn package — but the weights come from
-``models/firewatch-v{N}.pt`` produced by ``training/`` rather than the upstream
-pretrained checkpoint. The shared inference path lives in
-:class:`~streams.models.classifier_predictor.FireClassifierPredictor`.
+Loads ``models/firewatch-v{N}.pt`` produced by ``training/`` into our
+in-project :class:`~streams.models.fire_classifier.FireClassifier`. Same
+architecture and same input normalization as the legacy fire-detect-nn
+backend — only the weights differ.
 """
 from pathlib import Path
 from typing import Any, Tuple
 
 from streams.models.classifier_predictor import FireClassifierPredictor
+from streams.models.fire_classifier import FireClassifier
+from streams.models.preprocessing import build_inference_transform
 
 
 class FireWatch(FireClassifierPredictor):
@@ -29,14 +30,8 @@ class FireWatch(FireClassifierPredictor):
     def _load_weights(self, device) -> Tuple[Any, Any]:
         try:
             import torch
-            from fire_detect_nn.models import FireClassifier
-            from fire_detect_nn.datasets.combo import transform as fire_transform
         except ImportError as e:
-            raise ImportError(
-                "fire-detect-nn package required for FireClassifier architecture.\n"
-                "Run: python3 scripts/install_fire_detect_nn.py\n"
-                f"Original error: {e}"
-            )
+            raise ImportError(f"torch required: {e}")
 
         weights_path = Path(self.model_path)
         if not weights_path.exists():
@@ -54,4 +49,4 @@ class FireWatch(FireClassifierPredictor):
         model.to(device)
         print(f"✓ FireWatch model loaded successfully on {device}")
 
-        return model, fire_transform
+        return model, build_inference_transform()

--- a/streams/models/preprocessing.py
+++ b/streams/models/preprocessing.py
@@ -1,0 +1,28 @@
+"""Input preprocessing for the FireClassifier-based backends.
+
+Constants are empirical RGB statistics for the training distribution (not
+copyrightable expression). Both inference backends and the training pipeline
+import from here to guarantee identical normalization end-to-end.
+"""
+from __future__ import annotations
+
+from torchvision import transforms
+
+
+# Empirical RGB mean/std for the aerial fire imagery the upstream fire-detect-nn
+# pretrained checkpoint was trained on. The FireWatch v1 checkpoint was also
+# trained with these statistics for inference-time compatibility.
+IMG_SHAPE = (224, 224)
+RGB_MEAN = (0.4005, 0.3702, 0.3419)
+RGB_STD = (0.2858, 0.2749, 0.2742)
+
+
+def build_inference_transform():
+    """Deterministic PIL → Tensor transform used by every inference backend."""
+    return transforms.Compose(
+        [
+            transforms.Resize(IMG_SHAPE),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=RGB_MEAN, std=RGB_STD),
+        ]
+    )

--- a/tests/test_fire_detection_stream.py
+++ b/tests/test_fire_detection_stream.py
@@ -177,8 +177,10 @@ class TestFireDetectNNBackend:
         mock_model = Mock()
         mock_device = Mock()
         mock_transform = Mock()
-        with patch("streams.models.fire_detect_nn.FireDetectNN._load",
-                   return_value=(mock_model, mock_device, mock_transform)):
+        with patch("streams.models.fire_detect_nn.FireDetectNN._select_device",
+                   return_value=mock_device), \
+             patch("streams.models.fire_detect_nn.FireDetectNN._load_weights",
+                   return_value=(mock_model, mock_transform)):
             backend = FireDetectNN(confidence_threshold=0.5)
         return backend
 
@@ -245,8 +247,10 @@ class TestFireDetectionModelDispatcher:
         mock_config.IOU_THRESHOLD = 0.45
         mock_config.GRADCAM_EVERY_N_FIRE_FRAMES = 1
 
-        with patch("streams.models.fire_detect_nn.FireDetectNN._load",
-                   return_value=(Mock(), Mock(), Mock())):
+        with patch("streams.models.fire_detect_nn.FireDetectNN._select_device",
+                   return_value=Mock()), \
+             patch("streams.models.fire_detect_nn.FireDetectNN._load_weights",
+                   return_value=(Mock(), Mock())):
             model = FireDetectionModel()
 
         sentinel = {"has_fire": False, "fire_probability": 0.0, "detections": []}

--- a/tests/test_firewatch_backend.py
+++ b/tests/test_firewatch_backend.py
@@ -4,8 +4,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 import torch
-from fire_detect_nn.models import FireClassifier
-
+from streams.models.fire_classifier import FireClassifier
 from streams.models.firewatch import FireWatch
 
 

--- a/tests/test_firewatch_backend.py
+++ b/tests/test_firewatch_backend.py
@@ -1,0 +1,59 @@
+"""FireWatch backend loads a custom checkpoint and produces the canonical predict() dict."""
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from fire_detect_nn.models import FireClassifier
+
+from streams.models.firewatch import FireWatch
+
+
+@pytest.fixture(scope="module")
+def random_firewatch_checkpoint(tmp_path_factory):
+    """Build a randomly-initialized FireClassifier and save its state_dict."""
+    tmp_path = tmp_path_factory.mktemp("firewatch")
+    model = FireClassifier(backbone="densenet121", pretrained=False)
+    ckpt = tmp_path / "test_firewatch.pt"
+    torch.save(model.state_dict(), ckpt)
+    return ckpt
+
+
+def test_firewatch_backend_loads_checkpoint(random_firewatch_checkpoint):
+    backend = FireWatch(
+        model_path=str(random_firewatch_checkpoint),
+        confidence_threshold=0.5,
+        gradcam_every_n_fire_frames=1,
+    )
+    assert backend.model is not None
+    assert backend.fire_transform is not None
+    assert backend.device is not None
+    assert backend.MODEL_TYPE == "firewatch"
+
+
+def test_firewatch_predict_dict_shape(random_firewatch_checkpoint):
+    backend = FireWatch(
+        model_path=str(random_firewatch_checkpoint),
+        confidence_threshold=0.5,
+    )
+    frame = np.zeros((480, 640, 3), dtype=np.uint8)
+    result = backend.predict(frame)
+
+    expected_keys = {
+        "has_fire", "fire_probability", "detections", "timestamp",
+        "model_type", "no_fire_probability",
+    }
+    assert expected_keys.issubset(result.keys()), f"missing: {expected_keys - result.keys()}"
+    assert result["model_type"] == "firewatch"
+    assert isinstance(result["has_fire"], bool)
+    assert isinstance(result["detections"], list)
+    assert 0.0 <= result["fire_probability"] <= 1.0
+    assert 0.0 <= result["no_fire_probability"] <= 1.0
+
+
+def test_firewatch_missing_checkpoint_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        FireWatch(
+            model_path=str(tmp_path / "does_not_exist.pt"),
+            confidence_threshold=0.5,
+        )

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -22,10 +22,12 @@ class TestModelLoading:
         mock_device = Mock()
         mock_transform = Mock()
 
-        # Patch the loader hook used by FireDetectNN.__init__ so we don't touch
-        # torch / fire-detect-nn at all during this unit test.
-        with patch("streams.models.fire_detect_nn.FireDetectNN._load",
-                   return_value=(mock_model, mock_device, mock_transform)):
+        # Patch the loader hooks used by FireDetectNN.__init__ so we don't
+        # touch torch / fire-detect-nn at all during this unit test.
+        with patch("streams.models.fire_detect_nn.FireDetectNN._select_device",
+                   return_value=mock_device), \
+             patch("streams.models.fire_detect_nn.FireDetectNN._load_weights",
+                   return_value=(mock_model, mock_transform)):
             model = FireDetectionModel()
 
         assert model.use_fire_detect_nn is True
@@ -61,8 +63,10 @@ class TestModelLoading:
         mock_config.IOU_THRESHOLD = 0.45
         mock_config.GRADCAM_EVERY_N_FIRE_FRAMES = 1
 
-        with patch("streams.models.fire_detect_nn.FireDetectNN._load",
-                   return_value=(Mock(), Mock(), Mock())):
+        with patch("streams.models.fire_detect_nn.FireDetectNN._select_device",
+                   return_value=Mock()), \
+             patch("streams.models.fire_detect_nn.FireDetectNN._load_weights",
+                   return_value=(Mock(), Mock())):
             model = FireDetectionModel()
 
         assert model.confidence_threshold == 0.5

--- a/tests/test_training_dataset.py
+++ b/tests/test_training_dataset.py
@@ -1,0 +1,76 @@
+"""DFireDataset reads the YOLO-format directory shape and collapses to binary."""
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from training.data.datasets import DFireDataset
+
+
+def _make_jpg(path: Path, color=(255, 100, 100)):
+    """Create a minimal solid-color JPEG so PIL doesn't choke on empties."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    arr = np.zeros((32, 32, 3), dtype=np.uint8)
+    arr[:] = color
+    Image.fromarray(arr).save(path)
+
+
+def _make_fixture(root: Path):
+    """Build a 4-image D-Fire fixture: 2 positive (non-empty .txt), 2 negative (empty)."""
+    images_dir = root / "train" / "images"
+    labels_dir = root / "train" / "labels"
+    labels_dir.mkdir(parents=True, exist_ok=True)
+
+    _make_jpg(images_dir / "pos_001.jpg")
+    _make_jpg(images_dir / "pos_002.jpg")
+    _make_jpg(images_dir / "neg_001.jpg")
+    _make_jpg(images_dir / "neg_002.jpg")
+
+    # YOLO format: <class> <cx> <cy> <w> <h> (all normalized).
+    (labels_dir / "pos_001.txt").write_text("0 0.5 0.5 0.3 0.3\n")
+    (labels_dir / "pos_002.txt").write_text("1 0.4 0.4 0.2 0.2\n")
+    (labels_dir / "neg_001.txt").write_text("")
+    (labels_dir / "neg_002.txt").write_text("   \n")  # whitespace-only is still negative
+
+    # Also need test/ to exist for the constructor's structure check on `test`
+    # if anyone instantiates it — but the test only constructs `train`.
+    return root
+
+
+def test_dfire_dataset_binary_collapse(tmp_path):
+    root = _make_fixture(tmp_path)
+    ds = DFireDataset(root=root, split="train", transform=None)
+
+    assert len(ds) == 4
+    # Order is deterministic: sorted filename order from `iterdir`.
+    # neg_001, neg_002, pos_001, pos_002 → labels [0, 0, 1, 1].
+    assert ds.labels == [0, 0, 1, 1]
+
+
+def test_dfire_dataset_applies_transform(tmp_path):
+    from training.data.transforms import build_val_transform
+
+    root = _make_fixture(tmp_path)
+    ds = DFireDataset(root=root, split="train", transform=build_val_transform())
+
+    image, label = ds[0]
+    # build_val_transform Resize→ToTensor→Normalize → CHW float tensor
+    assert image.ndim == 3
+    assert image.shape[0] == 3
+    assert image.shape[1] == 224 and image.shape[2] == 224
+    assert label in (0, 1)
+
+
+def test_dfire_dataset_indices_subset(tmp_path):
+    root = _make_fixture(tmp_path)
+    # Take only the positive half (sorted order: neg, neg, pos, pos → indices 2, 3).
+    ds = DFireDataset(root=root, split="train", transform=None, indices=[2, 3])
+    assert len(ds) == 2
+    assert ds.labels == [1, 1]
+
+
+def test_dfire_dataset_missing_layout_errors(tmp_path):
+    # No train/images, no train/labels — should raise.
+    with pytest.raises(FileNotFoundError):
+        DFireDataset(root=tmp_path, split="train", transform=None)

--- a/training/__init__.py
+++ b/training/__init__.py
@@ -1,0 +1,12 @@
+"""FireWatch training pipeline.
+
+Trains a DenseNet121 binary fire/no-fire classifier on the D-Fire dataset
+using the same ``FireClassifier`` architecture the stream's classifier
+backend uses, so the resulting checkpoint is drop-in compatible.
+
+Entrypoints:
+    python -m training.data.datasets --download
+    python -m training.train --config training/configs/default.yaml
+    python -m training.eval  --checkpoint training/runs/<id>/best.pt
+    python -m training.export --checkpoint training/runs/<id>/best.pt
+"""

--- a/training/configs/default.yaml
+++ b/training/configs/default.yaml
@@ -1,0 +1,24 @@
+# Default training config for the FireWatch DenseNet121 classifier.
+# Override any field via CLI: `python -m training.train --epochs 2 --batch_size 16`.
+
+data:
+  cache_dir: ~/.cache/firewatch     # D-Fire is cloned to <cache_dir>/dfire/
+  num_workers: 4                    # DataLoader workers (drop to 0 if MPS multiprocessing flakes)
+  val_frac: 0.1                     # Fraction of train/ to use for validation
+  val_seed: 4822                    # Fixed seed for the train/val split (matches upstream convention)
+
+model:
+  backbone: densenet121
+  pretrained: true                  # Use ImageNet-init weights as starting point
+
+training:
+  batch_size: 32
+  epochs: 20
+  lr: 1.0e-4
+  weight_decay: 1.0e-4
+  warmup_epochs: 1                  # Linear warmup before cosine schedule kicks in
+  threshold: 0.5                    # Probability threshold for "fire" at eval time
+
+logging:
+  run_dir: training/runs            # TensorBoard + checkpoints land in <run_dir>/<run_id>/
+  log_every_n_steps: 50

--- a/training/data/datasets.py
+++ b/training/data/datasets.py
@@ -1,0 +1,191 @@
+"""D-Fire dataset loader and downloader.
+
+D-Fire (https://github.com/gaiasd/DFireDataset) ships YOLO-format annotations:
+each ``.txt`` label file is either empty (no fire/smoke present) or contains
+one line per bounding box. For binary fire/no-fire training we collapse:
+non-empty label file → label 1, empty → label 0.
+
+Expected on-disk layout after ``--download``::
+
+    <cache_dir>/dfire/
+    ├── train/
+    │   ├── images/  *.jpg
+    │   └── labels/  *.txt
+    └── test/
+        ├── images/
+        └── labels/
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable, List, Optional, Tuple
+
+from PIL import Image
+from torch.utils.data import Dataset
+
+
+DFIRE_REPO_URL = "https://github.com/gaiasd/DFireDataset.git"
+DEFAULT_CACHE_ROOT = Path(os.path.expanduser(os.environ.get("FIREWATCH_CACHE_DIR", "~/.cache/firewatch")))
+COMPLETE_MARKER = ".complete"
+
+
+def default_dfire_root(cache_dir: Optional[Path] = None) -> Path:
+    """Return ``<cache_dir>/dfire`` (resolving the cache root if not given)."""
+    cache_dir = Path(cache_dir).expanduser() if cache_dir is not None else DEFAULT_CACHE_ROOT
+    return cache_dir / "dfire"
+
+
+class DFireDataset(Dataset):
+    """Binary fire/no-fire over D-Fire.
+
+    Args:
+        root: Directory containing ``train/`` and ``test/`` subdirectories.
+        split: ``"train"`` or ``"test"``.
+        transform: PIL → Tensor transform (e.g. from ``training.data.transforms``).
+        indices: Optional list restricting which samples are exposed. Used by
+            ``training.train`` to carve out a deterministic val slice from the
+            train split without copying files around.
+    """
+
+    def __init__(
+        self,
+        root: Path,
+        split: str = "train",
+        transform: Optional[Callable] = None,
+        indices: Optional[List[int]] = None,
+    ):
+        if split not in ("train", "test"):
+            raise ValueError(f"split must be 'train' or 'test', got {split!r}")
+        self.root = Path(root)
+        self.split = split
+        self.transform = transform
+
+        images_dir = self.root / split / "images"
+        labels_dir = self.root / split / "labels"
+        if not images_dir.is_dir() or not labels_dir.is_dir():
+            raise FileNotFoundError(
+                f"Expected D-Fire layout at {self.root}: missing "
+                f"{images_dir.relative_to(self.root)} or {labels_dir.relative_to(self.root)}.\n"
+                "Run: python -m training.data.datasets --download"
+            )
+
+        # Build (image_path, label) pairs by pairing each image with its
+        # same-stem label file. Images without a label file are treated as
+        # no-fire (label 0) — D-Fire's convention is that missing labels
+        # are negatives.
+        samples: List[Tuple[Path, int]] = []
+        for image_path in sorted(images_dir.iterdir()):
+            if image_path.suffix.lower() not in (".jpg", ".jpeg", ".png"):
+                continue
+            label_path = labels_dir / f"{image_path.stem}.txt"
+            label = _label_from_yolo_file(label_path)
+            samples.append((image_path, label))
+
+        if not samples:
+            raise RuntimeError(f"No images found in {images_dir}")
+
+        self._samples = samples
+        self._indices = list(range(len(samples))) if indices is None else list(indices)
+
+    def __len__(self) -> int:
+        return len(self._indices)
+
+    def __getitem__(self, idx: int) -> Tuple:
+        image_path, label = self._samples[self._indices[idx]]
+        image = Image.open(image_path).convert("RGB")
+        if self.transform is not None:
+            image = self.transform(image)
+        return image, label
+
+    @property
+    def labels(self) -> List[int]:
+        """Labels in the order ``__getitem__`` returns them. Cheap; no I/O."""
+        return [self._samples[i][1] for i in self._indices]
+
+
+def _label_from_yolo_file(label_path: Path) -> int:
+    """Binary collapse: any non-whitespace content → 1, else 0 (incl. missing)."""
+    if not label_path.exists():
+        return 0
+    return 1 if label_path.read_text().strip() else 0
+
+
+def download_dfire(cache_dir: Optional[Path] = None) -> Path:
+    """Clone D-Fire to ``<cache_dir>/dfire`` if not already present.
+
+    Idempotent — checks for a ``.complete`` marker to skip work on re-runs.
+    Returns the dataset root path.
+    """
+    root = default_dfire_root(cache_dir)
+    marker = root / COMPLETE_MARKER
+
+    if marker.exists():
+        print(f"✓ D-Fire already present at {root}")
+        return root
+
+    root.parent.mkdir(parents=True, exist_ok=True)
+
+    if root.exists():
+        # Partial clone from a previous failed run.
+        print(f"Removing incomplete clone at {root}")
+        shutil.rmtree(root)
+
+    print(f"Cloning D-Fire from {DFIRE_REPO_URL} → {root}")
+    try:
+        subprocess.run(
+            ["git", "clone", "--depth", "1", DFIRE_REPO_URL, str(root)],
+            check=True,
+        )
+    except FileNotFoundError as e:
+        raise RuntimeError("git is required to clone D-Fire") from e
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"D-Fire clone failed (exit {e.returncode})") from e
+
+    marker.touch()
+    print(f"✓ D-Fire ready at {root}")
+    return root
+
+
+def print_class_balance(root: Path) -> None:
+    """Sanity-check the dataset layout and print positive/negative counts per split."""
+    for split in ("train", "test"):
+        try:
+            ds = DFireDataset(root=root, split=split, transform=None)
+        except FileNotFoundError as e:
+            print(f"⚠️  {split}: {e}")
+            continue
+        labels = ds.labels
+        n = len(labels)
+        pos = sum(labels)
+        pct = (pos / n * 100) if n else 0.0
+        print(f"{split:>5}: {n} images ({pos} positive, {pct:.1f}% fire)")
+
+
+def _main():
+    parser = argparse.ArgumentParser(description="D-Fire downloader / inspector")
+    parser.add_argument("--download", action="store_true", help="Clone D-Fire to the cache dir")
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=None,
+        help="Override cache root (default: $FIREWATCH_CACHE_DIR or ~/.cache/firewatch)",
+    )
+    args = parser.parse_args()
+
+    root = default_dfire_root(args.cache_dir)
+    if args.download:
+        root = download_dfire(args.cache_dir)
+    elif not root.exists():
+        print(f"D-Fire not found at {root}. Re-run with --download.")
+        sys.exit(1)
+
+    print_class_balance(root)
+
+
+if __name__ == "__main__":
+    _main()

--- a/training/data/transforms.py
+++ b/training/data/transforms.py
@@ -1,22 +1,18 @@
 """Train/val transforms for the FireWatch classifier.
 
 Both pipelines end with the same ``Normalize(RGB_MEAN, RGB_STD)`` step the
-upstream fire-detect-nn package uses at inference. Imported from the upstream
-package directly so we can't drift.
+inference backends use, imported from
+:mod:`streams.models.preprocessing` so train/inference can't drift.
 """
-from fire_detect_nn.datasets.combo import IMG_SHAPE, RGB_MEAN, RGB_STD
 from torchvision import transforms
+
+from streams.models.preprocessing import IMG_SHAPE, RGB_MEAN, RGB_STD, build_inference_transform
 
 
 def build_val_transform():
-    """Deterministic val/inference transform — matches upstream `combo.transform`."""
-    return transforms.Compose(
-        [
-            transforms.Resize(IMG_SHAPE),
-            transforms.ToTensor(),
-            transforms.Normalize(mean=RGB_MEAN, std=RGB_STD),
-        ]
-    )
+    """Deterministic val/inference transform — same as
+    :func:`streams.models.preprocessing.build_inference_transform`."""
+    return build_inference_transform()
 
 
 def build_train_transform():

--- a/training/data/transforms.py
+++ b/training/data/transforms.py
@@ -1,0 +1,33 @@
+"""Train/val transforms for the FireWatch classifier.
+
+Both pipelines end with the same ``Normalize(RGB_MEAN, RGB_STD)`` step the
+upstream fire-detect-nn package uses at inference. Imported from the upstream
+package directly so we can't drift.
+"""
+from fire_detect_nn.datasets.combo import IMG_SHAPE, RGB_MEAN, RGB_STD
+from torchvision import transforms
+
+
+def build_val_transform():
+    """Deterministic val/inference transform — matches upstream `combo.transform`."""
+    return transforms.Compose(
+        [
+            transforms.Resize(IMG_SHAPE),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=RGB_MEAN, std=RGB_STD),
+        ]
+    )
+
+
+def build_train_transform():
+    """Train-time augmentation. RandomResizedCrop scale matches typical fire imagery
+    (the subject often occupies a large fraction of the frame, so don't crop too aggressively)."""
+    return transforms.Compose(
+        [
+            transforms.RandomResizedCrop(IMG_SHAPE, scale=(0.7, 1.0)),
+            transforms.RandomHorizontalFlip(p=0.5),
+            transforms.ColorJitter(brightness=0.2, contrast=0.2, saturation=0.2),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=RGB_MEAN, std=RGB_STD),
+        ]
+    )

--- a/training/eval.py
+++ b/training/eval.py
@@ -1,0 +1,102 @@
+"""Evaluate a FireWatch checkpoint on the D-Fire test split.
+
+Reports AUROC, PR-AUC, and a precision/recall/F1 table across a sweep of
+thresholds. Operates on a logit-mode checkpoint (the kind ``train.py`` writes
+to ``best.pt`` / ``last.pt``).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader
+
+from training.data.datasets import DFireDataset, default_dfire_root
+from training.data.transforms import build_val_transform
+from training.model import build_model
+from training.train import select_device
+
+
+@torch.no_grad()
+def collect_predictions(model: nn.Module, loader: DataLoader, device: torch.device):
+    from tqdm import tqdm
+
+    model.eval()
+    sigmoid = nn.Sigmoid()
+    probs, labels = [], []
+    for images, lbls in tqdm(loader, desc="eval"):
+        images = images.to(device)
+        logits = model(images)
+        probs.extend(sigmoid(logits).cpu().numpy().ravel().tolist())
+        labels.extend(lbls.cpu().numpy().tolist())
+    return np.array(labels), np.array(probs)
+
+
+def threshold_sweep(labels: np.ndarray, probs: np.ndarray, thresholds=None):
+    from sklearn.metrics import confusion_matrix
+
+    thresholds = thresholds or [0.3, 0.4, 0.5, 0.6, 0.7]
+    rows = []
+    for thr in thresholds:
+        preds = (probs >= thr).astype(int)
+        tn, fp, fn, tp = confusion_matrix(labels, preds, labels=[0, 1]).ravel()
+        precision = tp / (tp + fp) if (tp + fp) else 0.0
+        recall = tp / (tp + fn) if (tp + fn) else 0.0
+        f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+        rows.append({"threshold": thr, "precision": precision, "recall": recall,
+                     "f1": f1, "tp": int(tp), "fp": int(fp), "fn": int(fn), "tn": int(tn)})
+    return rows
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Evaluate a FireWatch checkpoint")
+    parser.add_argument("--checkpoint", type=Path, required=True, help="Path to .pt state_dict")
+    parser.add_argument("--cache_dir", type=Path, default=None)
+    parser.add_argument("--batch_size", type=int, default=32)
+    parser.add_argument("--num_workers", type=int, default=4)
+    parser.add_argument("--split", type=str, default="test", choices=["train", "test"])
+    args = parser.parse_args()
+
+    device = select_device()
+    print(f"Device: {device}")
+
+    model = build_model(pretrained=False)
+    state_dict = torch.load(args.checkpoint, map_location=device)
+    model.load_state_dict(state_dict)
+    model.to(device)
+
+    dfire_root = default_dfire_root(args.cache_dir)
+    ds = DFireDataset(dfire_root, split=args.split, transform=build_val_transform())
+    loader = DataLoader(ds, batch_size=args.batch_size, shuffle=False, num_workers=args.num_workers)
+    print(f"{args.split}: {len(ds)} images")
+
+    from sklearn.metrics import average_precision_score, roc_auc_score
+
+    labels, probs = collect_predictions(model, loader, device)
+
+    auroc = roc_auc_score(labels, probs) if len(set(labels.tolist())) >= 2 else 0.0
+    pr_auc = average_precision_score(labels, probs) if len(set(labels.tolist())) >= 2 else 0.0
+    sweep = threshold_sweep(labels, probs)
+
+    print(f"\nSplit: {args.split}")
+    print(f"AUROC : {auroc:.4f}")
+    print(f"PR-AUC: {pr_auc:.4f}")
+    print(f"\n{'thr':>5}  {'prec':>6}  {'rec':>6}  {'f1':>6}  {'tp':>5}  {'fp':>5}  {'fn':>5}  {'tn':>5}")
+    for r in sweep:
+        print(f"{r['threshold']:>5.2f}  {r['precision']:>6.3f}  {r['recall']:>6.3f}  "
+              f"{r['f1']:>6.3f}  {r['tp']:>5}  {r['fp']:>5}  {r['fn']:>5}  {r['tn']:>5}")
+
+    report = {"split": args.split, "auroc": float(auroc), "pr_auc": float(pr_auc),
+              "threshold_sweep": sweep, "n_samples": len(labels)}
+    report_path = args.checkpoint.parent / f"eval_{args.split}.json"
+    with open(report_path, "w") as f:
+        json.dump(report, f, indent=2)
+    print(f"\nReport written to {report_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/training/export.py
+++ b/training/export.py
@@ -15,7 +15,8 @@ from datetime import datetime
 from pathlib import Path
 
 import torch
-from fire_detect_nn.models import FireClassifier
+
+from streams.models.fire_classifier import FireClassifier
 
 
 def next_version(models_dir: Path) -> int:

--- a/training/export.py
+++ b/training/export.py
@@ -1,0 +1,103 @@
+"""Export a training checkpoint as a deployable FireWatch model.
+
+Loads ``best.pt`` (sigmoid stripped during training), wraps it in a stock
+``FireClassifier`` (which has ``nn.Sigmoid()`` at the head), writes the
+state_dict to ``models/firewatch-v{N}.pt``, and emits a sidecar metadata
+JSON. ``{N}`` auto-increments to the next free slot under ``models/``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+import torch
+from fire_detect_nn.models import FireClassifier
+
+
+def next_version(models_dir: Path) -> int:
+    """Find the next free v{N} under models/."""
+    models_dir.mkdir(parents=True, exist_ok=True)
+    pattern = re.compile(r"firewatch-v(\d+)\.pt$")
+    used = []
+    for p in models_dir.iterdir():
+        m = pattern.match(p.name)
+        if m:
+            used.append(int(m.group(1)))
+    return (max(used) + 1) if used else 1
+
+
+def git_sha() -> str:
+    try:
+        return subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    except Exception:
+        return "unknown"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Export a FireWatch checkpoint for deployment")
+    parser.add_argument("--checkpoint", type=Path, required=True, help="Path to training-time .pt state_dict")
+    parser.add_argument("--models_dir", type=Path, default=Path("models"))
+    parser.add_argument("--version", type=int, default=None, help="Override auto-incremented version number")
+    parser.add_argument("--threshold", type=float, default=0.5, help="Inference threshold recorded in metadata")
+    args = parser.parse_args()
+
+    if not args.checkpoint.exists():
+        raise FileNotFoundError(f"checkpoint not found: {args.checkpoint}")
+
+    # Load training state_dict into a stock FireClassifier (which already has Sigmoid).
+    # Sigmoid has no params, so the state_dict from the logit-mode model loads cleanly.
+    model = FireClassifier(backbone="densenet121", pretrained=False)
+    state_dict = torch.load(args.checkpoint, map_location="cpu")
+    model.load_state_dict(state_dict)
+    model.eval()
+
+    version = args.version if args.version is not None else next_version(args.models_dir)
+    out_path = args.models_dir / f"firewatch-v{version}.pt"
+    meta_path = args.models_dir / f"firewatch-v{version}.metadata.json"
+
+    torch.save(model.state_dict(), out_path)
+    print(f"✓ Wrote {out_path}")
+
+    # Best-effort: pull training metrics from the sibling best_metrics.json.
+    metrics = {}
+    best_metrics_path = args.checkpoint.parent / "best_metrics.json"
+    if best_metrics_path.exists():
+        try:
+            metrics = json.loads(best_metrics_path.read_text())
+        except Exception:
+            metrics = {}
+
+    train_config_path = args.checkpoint.parent / "config.json"
+    train_config = {}
+    if train_config_path.exists():
+        try:
+            train_config = json.loads(train_config_path.read_text())
+        except Exception:
+            train_config = {}
+
+    metadata = {
+        "version": version,
+        "checkpoint_source": str(args.checkpoint),
+        "exported_at": datetime.utcnow().isoformat(),
+        "git_sha": git_sha(),
+        "architecture": "FireClassifier(backbone=densenet121)",
+        "input_shape": [3, 224, 224],
+        "normalization": {"mean": [0.4005, 0.3702, 0.3419], "std": [0.2858, 0.2749, 0.2742]},
+        "threshold": args.threshold,
+        "dataset": "D-Fire (https://github.com/gaiasd/DFireDataset)",
+        "training_metrics": metrics,
+        "training_config": train_config,
+    }
+    with open(meta_path, "w") as f:
+        json.dump(metadata, f, indent=2)
+    print(f"✓ Wrote {meta_path}")
+    print(f"\nDeploy with:")
+    print(f"  ML_MODEL_TYPE=firewatch FIREWATCH_MODEL_PATH={out_path} python -m streams")
+
+
+if __name__ == "__main__":
+    main()

--- a/training/model.py
+++ b/training/model.py
@@ -1,6 +1,6 @@
 """Build a FireClassifier for training.
 
-The upstream ``FireClassifier`` applies sigmoid in ``forward()`` — fine for
+The in-project ``FireClassifier`` applies sigmoid in ``forward()`` — fine for
 inference but numerically unstable for BCE loss. We swap the sigmoid out for
 ``nn.Identity`` so training can use ``BCEWithLogitsLoss``, then ``export.py``
 re-attaches the real sigmoid before writing the deployable checkpoint. The
@@ -9,7 +9,8 @@ state_dict is identical either way (sigmoid has no parameters).
 from __future__ import annotations
 
 import torch.nn as nn
-from fire_detect_nn.models import FireClassifier
+
+from streams.models.fire_classifier import FireClassifier
 
 
 def build_model(pretrained: bool = True, backbone: str = "densenet121") -> FireClassifier:
@@ -30,7 +31,5 @@ def build_model(pretrained: bool = True, backbone: str = "densenet121") -> FireC
 
 def restore_sigmoid(model: FireClassifier) -> FireClassifier:
     """Re-attach ``nn.Sigmoid`` for inference. Mirror of ``build_model``."""
-    import torch.nn as nn
-
     model.sigmoid = nn.Sigmoid()
     return model

--- a/training/model.py
+++ b/training/model.py
@@ -1,0 +1,36 @@
+"""Build a FireClassifier for training.
+
+The upstream ``FireClassifier`` applies sigmoid in ``forward()`` — fine for
+inference but numerically unstable for BCE loss. We swap the sigmoid out for
+``nn.Identity`` so training can use ``BCEWithLogitsLoss``, then ``export.py``
+re-attaches the real sigmoid before writing the deployable checkpoint. The
+state_dict is identical either way (sigmoid has no parameters).
+"""
+from __future__ import annotations
+
+import torch.nn as nn
+from fire_detect_nn.models import FireClassifier
+
+
+def build_model(pretrained: bool = True, backbone: str = "densenet121") -> FireClassifier:
+    """Return a ``FireClassifier`` configured for logit-mode training.
+
+    Args:
+        pretrained: If True, init the DenseNet121 backbone with ImageNet weights.
+            Should be True for from-scratch training; False when loading our
+            own state_dict afterwards.
+        backbone: Passed to ``FireClassifier``. Only ``densenet121`` is
+            supported end-to-end (the inference path expects DenseNet features).
+    """
+    model = FireClassifier(backbone=backbone, pretrained=pretrained)
+    # Strip the sigmoid so the model emits logits — required for BCEWithLogitsLoss.
+    model.sigmoid = nn.Identity()
+    return model
+
+
+def restore_sigmoid(model: FireClassifier) -> FireClassifier:
+    """Re-attach ``nn.Sigmoid`` for inference. Mirror of ``build_model``."""
+    import torch.nn as nn
+
+    model.sigmoid = nn.Sigmoid()
+    return model

--- a/training/train.py
+++ b/training/train.py
@@ -1,0 +1,309 @@
+"""Train the FireWatch DenseNet121 classifier on D-Fire.
+
+Quickstart:
+    python -m training.train --config training/configs/default.yaml
+    python -m training.train --epochs 2 --batch_size 16            # smoke test
+    python -m training.train --max_steps 4                          # 4 batches per epoch
+
+Best-AUROC checkpoint lands at ``training/runs/<run_id>/best.pt``; ``last.pt``
+is also written each epoch for resuming. ``training/export.py`` turns
+``best.pt`` into a deployable ``models/firewatch-v{N}.pt`` with the sigmoid
+re-attached.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+import yaml
+from torch.optim import AdamW
+from torch.optim.lr_scheduler import CosineAnnealingLR, LinearLR, SequentialLR
+from torch.utils.data import DataLoader
+
+from training.data.datasets import DFireDataset, default_dfire_root, download_dfire
+from training.data.transforms import build_train_transform, build_val_transform
+from training.model import build_model
+
+
+def select_device() -> torch.device:
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        return torch.device("mps")
+    return torch.device("cpu")
+
+
+def load_config(config_path: Optional[Path]) -> Dict[str, Any]:
+    if config_path is None:
+        return {}
+    with open(config_path, "r") as f:
+        return yaml.safe_load(f)
+
+
+def _get(cfg: Dict[str, Any], path: str, default: Any) -> Any:
+    """Nested-dict lookup with dotted path: ``_get(cfg, 'training.lr', 1e-4)``."""
+    node: Any = cfg
+    for part in path.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return default
+        node = node[part]
+    return node
+
+
+def make_split_indices(n_train: int, val_frac: float, seed: int) -> Tuple[List[int], List[int]]:
+    """Deterministic shuffle, then carve `val_frac` off the front for val."""
+    rng = np.random.default_rng(seed)
+    indices = np.arange(n_train)
+    rng.shuffle(indices)
+    n_val = int(np.floor(val_frac * n_train))
+    return indices[n_val:].tolist(), indices[:n_val].tolist()
+
+
+def make_dataloaders(
+    dfire_root: Path,
+    val_frac: float,
+    val_seed: int,
+    batch_size: int,
+    num_workers: int,
+) -> Tuple[DataLoader, DataLoader]:
+    # First pass to discover total train sample count (no transform; cheap).
+    full_train = DFireDataset(dfire_root, split="train", transform=None)
+    train_idxs, val_idxs = make_split_indices(len(full_train), val_frac, val_seed)
+
+    train_ds = DFireDataset(
+        dfire_root, split="train", transform=build_train_transform(), indices=train_idxs
+    )
+    val_ds = DFireDataset(
+        dfire_root, split="train", transform=build_val_transform(), indices=val_idxs
+    )
+
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=batch_size,
+        shuffle=True,
+        num_workers=num_workers,
+        pin_memory=False,
+        drop_last=True,
+    )
+    val_loader = DataLoader(
+        val_ds,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+        pin_memory=False,
+    )
+    return train_loader, val_loader
+
+
+def make_scheduler(optimizer: AdamW, warmup_epochs: int, total_epochs: int):
+    """LinearLR warmup → CosineAnnealingLR. Stepped per epoch."""
+    if warmup_epochs <= 0:
+        return CosineAnnealingLR(optimizer, T_max=total_epochs)
+    warmup = LinearLR(optimizer, start_factor=0.1, end_factor=1.0, total_iters=warmup_epochs)
+    cosine = CosineAnnealingLR(optimizer, T_max=max(1, total_epochs - warmup_epochs))
+    return SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[warmup_epochs])
+
+
+def train_one_epoch(
+    model: nn.Module,
+    loader: DataLoader,
+    criterion: nn.Module,
+    optimizer: AdamW,
+    device: torch.device,
+    writer,
+    global_step: int,
+    log_every_n_steps: int,
+    max_steps: Optional[int],
+) -> Tuple[float, int]:
+    from tqdm import tqdm
+
+    model.train()
+    losses: List[float] = []
+    pbar = tqdm(loader, desc="train", leave=False)
+    for step, (images, labels) in enumerate(pbar):
+        if max_steps is not None and step >= max_steps:
+            break
+        images = images.to(device, non_blocking=True)
+        labels = labels.float().to(device, non_blocking=True).unsqueeze(1)
+
+        optimizer.zero_grad(set_to_none=True)
+        logits = model(images)
+        loss = criterion(logits, labels)
+        loss.backward()
+        optimizer.step()
+
+        loss_val = loss.item()
+        losses.append(loss_val)
+        global_step += 1
+        if global_step % log_every_n_steps == 0:
+            writer.add_scalar("train/loss", loss_val, global_step)
+            pbar.set_postfix(loss=f"{loss_val:.4f}")
+
+    return float(np.mean(losses)) if losses else 0.0, global_step
+
+
+@torch.no_grad()
+def evaluate(
+    model: nn.Module,
+    loader: DataLoader,
+    criterion: nn.Module,
+    device: torch.device,
+    max_steps: Optional[int] = None,
+) -> Dict[str, float]:
+    from tqdm import tqdm
+
+    model.eval()
+    all_probs: List[float] = []
+    all_labels: List[int] = []
+    losses: List[float] = []
+    sigmoid = nn.Sigmoid()
+    for step, (images, labels) in enumerate(tqdm(loader, desc="val", leave=False)):
+        if max_steps is not None and step >= max_steps:
+            break
+        images = images.to(device, non_blocking=True)
+        labels_t = labels.float().to(device, non_blocking=True).unsqueeze(1)
+        logits = model(images)
+        loss = criterion(logits, labels_t)
+        losses.append(loss.item())
+        probs = sigmoid(logits).cpu().numpy().ravel()
+        all_probs.extend(probs.tolist())
+        all_labels.extend(labels.cpu().numpy().tolist())
+
+    from sklearn.metrics import average_precision_score, roc_auc_score
+
+    metrics = {"val_loss": float(np.mean(losses)) if losses else 0.0}
+    # AUROC/PR-AUC require both classes present in the labels.
+    if len(set(all_labels)) >= 2:
+        metrics["val_auroc"] = float(roc_auc_score(all_labels, all_probs))
+        metrics["val_pr_auc"] = float(average_precision_score(all_labels, all_probs))
+    else:
+        metrics["val_auroc"] = 0.0
+        metrics["val_pr_auc"] = 0.0
+    return metrics
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train FireWatch DenseNet121 on D-Fire")
+    parser.add_argument("--config", type=Path, default=Path("training/configs/default.yaml"))
+    parser.add_argument("--epochs", type=int, default=None)
+    parser.add_argument("--batch_size", type=int, default=None)
+    parser.add_argument("--lr", type=float, default=None)
+    parser.add_argument("--num_workers", type=int, default=None)
+    parser.add_argument("--max_steps", type=int, default=None, help="Cap batches per epoch (smoke test)")
+    parser.add_argument("--cache_dir", type=Path, default=None, help="Override D-Fire cache root")
+    parser.add_argument("--run_id", type=str, default=None, help="Override the run id (default: timestamp)")
+    parser.add_argument("--no-download", action="store_true", help="Don't attempt to download D-Fire if missing")
+    args = parser.parse_args()
+
+    cfg = load_config(args.config)
+
+    # Resolve all hyperparameters: CLI overrides YAML, YAML overrides built-in defaults.
+    epochs = args.epochs if args.epochs is not None else _get(cfg, "training.epochs", 20)
+    batch_size = args.batch_size if args.batch_size is not None else _get(cfg, "training.batch_size", 32)
+    lr = args.lr if args.lr is not None else float(_get(cfg, "training.lr", 1e-4))
+    weight_decay = float(_get(cfg, "training.weight_decay", 1e-4))
+    warmup_epochs = int(_get(cfg, "training.warmup_epochs", 1))
+    num_workers = args.num_workers if args.num_workers is not None else _get(cfg, "data.num_workers", 4)
+    val_frac = float(_get(cfg, "data.val_frac", 0.1))
+    val_seed = int(_get(cfg, "data.val_seed", 4822))
+    pretrained = bool(_get(cfg, "model.pretrained", True))
+    backbone = _get(cfg, "model.backbone", "densenet121")
+    run_dir_root = Path(_get(cfg, "logging.run_dir", "training/runs"))
+    log_every_n_steps = int(_get(cfg, "logging.log_every_n_steps", 50))
+
+    # Reproducibility — fix Python/numpy/torch seeds.
+    random.seed(val_seed)
+    np.random.seed(val_seed)
+    torch.manual_seed(val_seed)
+
+    device = select_device()
+    print(f"Device: {device}")
+
+    # Dataset
+    dfire_root = default_dfire_root(args.cache_dir)
+    if not dfire_root.exists() and not args.no_download:
+        download_dfire(args.cache_dir)
+    train_loader, val_loader = make_dataloaders(
+        dfire_root, val_frac=val_frac, val_seed=val_seed, batch_size=batch_size, num_workers=num_workers
+    )
+    print(f"Train batches: {len(train_loader)}, Val batches: {len(val_loader)}")
+
+    # Model / loss / optim
+    model = build_model(pretrained=pretrained, backbone=backbone).to(device)
+    criterion = nn.BCEWithLogitsLoss()
+    optimizer = AdamW(model.parameters(), lr=lr, weight_decay=weight_decay)
+    scheduler = make_scheduler(optimizer, warmup_epochs=warmup_epochs, total_epochs=epochs)
+
+    # Run dir
+    from torch.utils.tensorboard import SummaryWriter
+
+    run_id = args.run_id or datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    run_dir = run_dir_root / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    writer = SummaryWriter(log_dir=str(run_dir))
+    print(f"Run dir: {run_dir}")
+
+    # Save the resolved config for traceability.
+    with open(run_dir / "config.json", "w") as f:
+        json.dump(
+            {
+                "epochs": epochs, "batch_size": batch_size, "lr": lr, "weight_decay": weight_decay,
+                "warmup_epochs": warmup_epochs, "num_workers": num_workers, "val_frac": val_frac,
+                "val_seed": val_seed, "pretrained": pretrained, "backbone": backbone,
+                "device": str(device), "max_steps": args.max_steps,
+                "started_at": datetime.utcnow().isoformat(),
+            },
+            f,
+            indent=2,
+        )
+
+    best_auroc = -1.0
+    global_step = 0
+    for epoch in range(1, epochs + 1):
+        t0 = time.time()
+        train_loss, global_step = train_one_epoch(
+            model, train_loader, criterion, optimizer, device,
+            writer, global_step, log_every_n_steps, args.max_steps,
+        )
+        val_metrics = evaluate(model, val_loader, criterion, device, max_steps=args.max_steps)
+        scheduler.step()
+        elapsed = time.time() - t0
+
+        writer.add_scalar("train/loss_epoch", train_loss, epoch)
+        writer.add_scalar("val/loss", val_metrics["val_loss"], epoch)
+        writer.add_scalar("val/auroc", val_metrics["val_auroc"], epoch)
+        writer.add_scalar("val/pr_auc", val_metrics["val_pr_auc"], epoch)
+        writer.add_scalar("lr", optimizer.param_groups[0]["lr"], epoch)
+
+        print(
+            f"epoch {epoch:>3}/{epochs}  "
+            f"train_loss={train_loss:.4f}  "
+            f"val_loss={val_metrics['val_loss']:.4f}  "
+            f"auroc={val_metrics['val_auroc']:.4f}  "
+            f"pr_auc={val_metrics['val_pr_auc']:.4f}  "
+            f"({elapsed:.1f}s)"
+        )
+
+        torch.save(model.state_dict(), run_dir / "last.pt")
+        if val_metrics["val_auroc"] > best_auroc:
+            best_auroc = val_metrics["val_auroc"]
+            torch.save(model.state_dict(), run_dir / "best.pt")
+            with open(run_dir / "best_metrics.json", "w") as f:
+                json.dump({"epoch": epoch, **val_metrics}, f, indent=2)
+
+    writer.close()
+    print(f"\n✓ Training complete. Best val AUROC: {best_auroc:.4f}")
+    print(f"Checkpoint: {run_dir}/best.pt")
+    print(f"Next: python -m training.export --checkpoint {run_dir}/best.pt")
+
+
+if __name__ == "__main__":
+    main()

--- a/training/train.py
+++ b/training/train.py
@@ -127,17 +127,30 @@ def train_one_epoch(
 
     model.train()
     losses: List[float] = []
+    skipped = 0
     pbar = tqdm(loader, desc="train", leave=False)
     for step, (images, labels) in enumerate(pbar):
         if max_steps is not None and step >= max_steps:
             break
-        images = images.to(device, non_blocking=True)
-        labels = labels.float().to(device, non_blocking=True).unsqueeze(1)
+        # non_blocking=True triggered numerical corruption on MPS during smoke
+        # testing — sync transfers are barely slower and keep autograd sane.
+        images = images.to(device)
+        labels = labels.float().to(device).unsqueeze(1)
 
-        optimizer.zero_grad(set_to_none=True)
+        optimizer.zero_grad()
         logits = model(images)
         loss = criterion(logits, labels)
+        # Skip batches that produce non-finite loss (rare MPS-side instability
+        # at the very start of training); also catches any future regression.
+        if not torch.isfinite(loss):
+            skipped += 1
+            optimizer.zero_grad()
+            continue
         loss.backward()
+        # Standard precaution for fine-tuning a pretrained backbone with a
+        # randomly-initialized head — bounds early gradients while the new
+        # Linear settles into a sensible scale.
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=5.0)
         optimizer.step()
 
         loss_val = loss.item()
@@ -146,6 +159,8 @@ def train_one_epoch(
         if global_step % log_every_n_steps == 0:
             writer.add_scalar("train/loss", loss_val, global_step)
             pbar.set_postfix(loss=f"{loss_val:.4f}")
+    if skipped:
+        print(f"  (skipped {skipped} non-finite-loss batches this epoch)")
 
     return float(np.mean(losses)) if losses else 0.0, global_step
 
@@ -168,8 +183,8 @@ def evaluate(
     for step, (images, labels) in enumerate(tqdm(loader, desc="val", leave=False)):
         if max_steps is not None and step >= max_steps:
             break
-        images = images.to(device, non_blocking=True)
-        labels_t = labels.float().to(device, non_blocking=True).unsqueeze(1)
+        images = images.to(device)
+        labels_t = labels.float().to(device).unsqueeze(1)
         logits = model(images)
         loss = criterion(logits, labels_t)
         losses.append(loss.item())


### PR DESCRIPTION
## Summary

Adds an in-house training pipeline and a self-trained `firewatch` model backend. The pipeline trains a DenseNet121 binary fire classifier on the D-Fire dataset and exports a versioned checkpoint that the streaming consumer can load via `ML_MODEL_TYPE=firewatch`.

This is a pure addition — no existing backend is removed (license cleanup of the unlicensed/AGPL backends ships in Phase 5).

## What got built

- **`training/` package** — `data/datasets.py` (D-Fire loader from HF parquet mirror), `data/transforms.py`, `model.py` (logit-mode wrapper), `train.py` (AdamW + cosine LR + AUROC checkpoint + tensorboard + tqdm), `eval.py` (AUROC + PR-AUC + threshold sweep), `export.py` (auto-versioned `models/firewatch-v{N}.pt` + metadata.json), `configs/default.yaml`.
- **`streams/models/firewatch.py`** — new backend, structurally identical to `fire-detect-nn` but loads our own checkpoint.
- **`streams/models/classifier_predictor.py`** — shared base extracted from `FireDetectNN`. Both backends inherit `predict()`/GradCAM/device-selection.
- **`streams/models/fire_classifier.py`** — in-project reimplementation of `FireClassifier` (DenseNet121 + sigmoid). Replaces the import of the unlicensed upstream class. State-dict keys match — both `firewatch-v1.pt` and the upstream pretrained `.pt` load through it.
- **`streams/models/preprocessing.py`** — `RGB_MEAN`/`RGB_STD`/`IMG_SHAPE` constants + `build_inference_transform()`. Single source of truth so train/inference can't drift.

## Trained model

- `models/firewatch-v1.pt` (28 MB) — DenseNet121, trained 20 epochs on D-Fire (17,221 train + 4,306 test images, materialized from the `badsaarow/d-fire` HF parquet mirror).
- `models/firewatch-v1.metadata.json` — git SHA, training config, dataset, normalization, metrics.

Both files are gitignored (`models/*`) — they are produced artifacts, not source.

## Metrics

| Split | AUROC | PR-AUC | F1 @ 0.5 |
|-------|------:|-------:|---------:|
| Val (10% of train, 1,721 imgs) | 0.9982 | 0.9987 | — |
| Test (4,306 imgs, held out) | 0.9976 | 0.9979 | 0.984 |

At threshold 0.5: 2269 TP / 41 FP / 32 FN / 1964 TN. Zero non-finite-loss skips after the MPS transfer-race fix.

## Commits

- `c067c91` — Phase 4: training pipeline + firewatch model backend
- `7555d81` — training: fix MPS transfer race + add grad clipping + non-finite-loss guard
- `66b854c` — Restore MIT LICENSE
- `0f14a04` — Drop fire-detect-nn package dep; reimplement FireClassifier in-project

## Test plan

- [x] `pytest -o addopts="--tb=line"` → **84 passed** locally on `claude/phase-4-training`
- [ ] Real-world video smoke tests follow in a separate "Phase 4 verification" PR (trail-cam clips through both the local pipeline and a minimal Modal-hosted inference path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)